### PR TITLE
feat: add reading voucher with upload and claim

### DIFF
--- a/src/main/java/com/shanzha/domain/ReadingVoucher.java
+++ b/src/main/java/com/shanzha/domain/ReadingVoucher.java
@@ -1,0 +1,128 @@
+package com.shanzha.domain;
+
+import jakarta.persistence.*;
+import java.io.Serializable;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * A ReadingVoucher.
+ */
+@Entity
+@Table(name = "reading_voucher")
+public class ReadingVoucher implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, unique = true)
+    private String code;
+
+    @Column(name = "issued_at")
+    private Instant issuedAt;
+
+    @Column(name = "expires_at")
+    private Instant expiresAt;
+
+    @Column(name = "claimed_by")
+    private String claimedBy;
+
+    @Lob
+    @Column(name = "file")
+    private byte[] file;
+
+    @Column(name = "file_content_type")
+    private String fileContentType;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public Instant getIssuedAt() {
+        return issuedAt;
+    }
+
+    public void setIssuedAt(Instant issuedAt) {
+        this.issuedAt = issuedAt;
+    }
+
+    public Instant getExpiresAt() {
+        return expiresAt;
+    }
+
+    public void setExpiresAt(Instant expiresAt) {
+        this.expiresAt = expiresAt;
+    }
+
+    public String getClaimedBy() {
+        return claimedBy;
+    }
+
+    public void setClaimedBy(String claimedBy) {
+        this.claimedBy = claimedBy;
+    }
+
+    public byte[] getFile() {
+        return file;
+    }
+
+    public void setFile(byte[] file) {
+        this.file = file;
+    }
+
+    public String getFileContentType() {
+        return fileContentType;
+    }
+
+    public void setFileContentType(String fileContentType) {
+        this.fileContentType = fileContentType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ReadingVoucher that = (ReadingVoucher) o;
+        return id != null && Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    @Override
+    public String toString() {
+        return (
+            "ReadingVoucher{" +
+            "id=" +
+            id +
+            ", code='" +
+            code +
+            '\'' +
+            ", issuedAt=" +
+            issuedAt +
+            ", expiresAt=" +
+            expiresAt +
+            ", claimedBy='" +
+            claimedBy +
+            '\'' +
+            "}"
+        );
+    }
+}

--- a/src/main/java/com/shanzha/repository/ReadingVoucherRepository.java
+++ b/src/main/java/com/shanzha/repository/ReadingVoucherRepository.java
@@ -1,0 +1,15 @@
+package com.shanzha.repository;
+
+import com.shanzha.domain.ReadingVoucher;
+import java.time.Instant;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data JPA repository for the ReadingVoucher entity.
+ */
+@Repository
+public interface ReadingVoucherRepository extends JpaRepository<ReadingVoucher, Long> {
+    Optional<ReadingVoucher> findFirstByClaimedByIsNullOrderByIssuedAtAsc();
+}

--- a/src/main/java/com/shanzha/service/ReadingVoucherService.java
+++ b/src/main/java/com/shanzha/service/ReadingVoucherService.java
@@ -1,0 +1,61 @@
+package com.shanzha.service;
+
+import com.shanzha.domain.ReadingVoucher;
+import com.shanzha.repository.ReadingVoucherRepository;
+import java.io.IOException;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Service for managing {@link ReadingVoucher}.
+ */
+@Service
+@Transactional
+public class ReadingVoucherService {
+
+    private final ReadingVoucherRepository readingVoucherRepository;
+
+    public ReadingVoucherService(ReadingVoucherRepository readingVoucherRepository) {
+        this.readingVoucherRepository = readingVoucherRepository;
+    }
+
+    public ReadingVoucher saveWithFile(MultipartFile file) throws IOException {
+        ReadingVoucher voucher = new ReadingVoucher();
+        voucher.setCode(UUID.randomUUID().toString());
+        voucher.setIssuedAt(Instant.now());
+        voucher.setExpiresAt(Instant.now().plus(1, ChronoUnit.DAYS));
+        voucher.setFile(file.getBytes());
+        voucher.setFileContentType(file.getContentType());
+        return readingVoucherRepository.save(voucher);
+    }
+
+    public Optional<ReadingVoucher> claimVoucher(String userLogin) {
+        return readingVoucherRepository
+            .findFirstByClaimedByIsNullOrderByIssuedAtAsc()
+            .map(voucher -> {
+                voucher.setClaimedBy(userLogin);
+                return voucher;
+            });
+    }
+
+    @Scheduled(fixedRate = 86_400_000)
+    public void issuePeriodicVoucher() {
+        ReadingVoucher voucher = new ReadingVoucher();
+        voucher.setCode(UUID.randomUUID().toString());
+        voucher.setIssuedAt(Instant.now());
+        voucher.setExpiresAt(Instant.now().plus(1, ChronoUnit.DAYS));
+        readingVoucherRepository.save(voucher);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ReadingVoucher> findAll() {
+        return readingVoucherRepository.findAll();
+    }
+}

--- a/src/main/java/com/shanzha/web/rest/ReadingVoucherResource.java
+++ b/src/main/java/com/shanzha/web/rest/ReadingVoucherResource.java
@@ -1,0 +1,48 @@
+package com.shanzha.web.rest;
+
+import com.shanzha.domain.ReadingVoucher;
+import com.shanzha.service.ReadingVoucherService;
+import java.io.IOException;
+import java.security.Principal;
+import java.util.List;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * REST controller for managing {@link ReadingVoucher}.
+ */
+@RestController
+@RequestMapping("/api/reading-vouchers")
+public class ReadingVoucherResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReadingVoucherResource.class);
+
+    private final ReadingVoucherService readingVoucherService;
+
+    public ReadingVoucherResource(ReadingVoucherService readingVoucherService) {
+        this.readingVoucherService = readingVoucherService;
+    }
+
+    @PostMapping("/upload")
+    public ResponseEntity<ReadingVoucher> upload(@RequestParam("file") MultipartFile file) throws IOException {
+        LOG.debug("REST request to upload file : {}", file.getOriginalFilename());
+        ReadingVoucher result = readingVoucherService.saveWithFile(file);
+        return ResponseEntity.ok(result);
+    }
+
+    @PostMapping("/claim")
+    public ResponseEntity<ReadingVoucher> claim(Principal principal) {
+        LOG.debug("REST request to claim voucher by : {}", principal.getName());
+        Optional<ReadingVoucher> voucher = readingVoucherService.claimVoucher(principal.getName());
+        return voucher.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping
+    public List<ReadingVoucher> getAll() {
+        return readingVoucherService.findAll();
+    }
+}

--- a/src/main/resources/config/liquibase/changelog/20250724000000_added_entity_ReadingVoucher.xml
+++ b/src/main/resources/config/liquibase/changelog/20250724000000_added_entity_ReadingVoucher.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <!--
+        Added the entity ReadingVoucher.
+    -->
+    <changeSet id="20250724000000-1" author="jhipster">
+        <createTable tableName="reading_voucher">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <column name="code" type="varchar(255)">
+                <constraints nullable="false" unique="true"/>
+            </column>
+            <column name="issued_at" type="${datetimeType}"/>
+            <column name="expires_at" type="${datetimeType}"/>
+            <column name="claimed_by" type="varchar(255)"/>
+            <column name="file" type="${blobType}"/>
+            <column name="file_content_type" type="varchar(255)"/>
+            <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here -->
+        </createTable>
+    </changeSet>
+
+    <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here -->
+</databaseChangeLog>

--- a/src/main/resources/config/liquibase/master.xml
+++ b/src/main/resources/config/liquibase/master.xml
@@ -12,6 +12,7 @@
     <property name="timeType" value="time(6)" dbms="mysql"/>
 
     <include file="config/liquibase/changelog/00000000000000_initial_schema.xml" relativeToChangelogFile="false"/>
+    <include file="config/liquibase/changelog/20250724000000_added_entity_ReadingVoucher.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
     <!-- jhipster-needle-liquibase-add-incremental-changelog - JHipster will add incremental liquibase changelogs here -->

--- a/src/main/webapp/app/entities/entities-menu.vue
+++ b/src/main/webapp/app/entities/entities-menu.vue
@@ -1,5 +1,6 @@
 <template>
   <div>
+    <router-link to="/reading-voucher" class="dropdown-item">Reading Vouchers</router-link>
     <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
   </div>
 </template>

--- a/src/main/webapp/app/entities/entities.component.ts
+++ b/src/main/webapp/app/entities/entities.component.ts
@@ -1,6 +1,7 @@
 import { defineComponent, provide } from 'vue';
 
 import UserService from '@/entities/user/user.service';
+import ReadingVoucherService from '@/entities/reading-voucher/reading-voucher.service';
 // jhipster-needle-add-entity-service-to-entities-component-import - JHipster will import entities services here
 
 export default defineComponent({
@@ -8,6 +9,7 @@ export default defineComponent({
   name: 'Entities',
   setup() {
     provide('userService', () => new UserService());
+    provide('readingVoucherService', () => new ReadingVoucherService());
     // jhipster-needle-add-entity-service-to-entities-component - JHipster will import entities services here
   },
 });

--- a/src/main/webapp/app/entities/reading-voucher/reading-voucher.component.ts
+++ b/src/main/webapp/app/entities/reading-voucher/reading-voucher.component.ts
@@ -1,0 +1,32 @@
+import { defineComponent, inject, ref } from 'vue';
+import type ReadingVoucherService from './reading-voucher.service';
+
+export default defineComponent({
+  compatConfig: { MODE: 3 },
+  name: 'ReadingVoucher',
+  setup() {
+    const readingVoucherService = inject('readingVoucherService') as () => ReadingVoucherService;
+    const file = ref<File | null>(null);
+    const claimedCode = ref('');
+
+    const upload = () => {
+      if (file.value) {
+        readingVoucherService()
+          .upload(file.value)
+          .then(() => {
+            file.value = null;
+          });
+      }
+    };
+
+    const claimVoucher = () => {
+      readingVoucherService()
+        .claim()
+        .then(res => {
+          claimedCode.value = res.data.code;
+        });
+    };
+
+    return { file, upload, claimVoucher, claimedCode };
+  },
+});

--- a/src/main/webapp/app/entities/reading-voucher/reading-voucher.service.ts
+++ b/src/main/webapp/app/entities/reading-voucher/reading-voucher.service.ts
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+export default class ReadingVoucherService {
+  public upload(file: File): Promise<any> {
+    const formData = new FormData();
+    formData.append('file', file);
+    return axios.post('api/reading-vouchers/upload', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+  }
+
+  public claim(): Promise<any> {
+    return axios.post('api/reading-vouchers/claim');
+  }
+
+  public retrieve(): Promise<any> {
+    return axios.get('api/reading-vouchers');
+  }
+}

--- a/src/main/webapp/app/entities/reading-voucher/reading-voucher.vue
+++ b/src/main/webapp/app/entities/reading-voucher/reading-voucher.vue
@@ -1,0 +1,13 @@
+<template>
+  <div>
+    <h2 id="reading-voucher-heading">Reading Vouchers</h2>
+    <b-form @submit.prevent="upload">
+      <b-form-file v-model="file" required></b-form-file>
+      <b-button type="submit" variant="primary" class="mt-2">Upload</b-button>
+    </b-form>
+    <b-button class="mt-3" variant="success" @click="claimVoucher">Claim Voucher</b-button>
+    <div v-if="claimedCode" class="alert alert-info mt-3">Claimed voucher: {{ claimedCode }}</div>
+  </div>
+</template>
+
+<script lang="ts" src="./reading-voucher.component.ts"></script>

--- a/src/main/webapp/app/router/entities.ts
+++ b/src/main/webapp/app/router/entities.ts
@@ -1,11 +1,17 @@
 const Entities = () => import('@/entities/entities.vue');
 
 // jhipster-needle-add-entity-to-router-import - JHipster will import entities to the router here
+const ReadingVoucher = () => import('@/entities/reading-voucher/reading-voucher.vue');
 
 export default {
   path: '/',
   component: Entities,
   children: [
+    {
+      path: 'reading-voucher',
+      name: 'ReadingVoucher',
+      component: ReadingVoucher,
+    },
     // jhipster-needle-add-entity-to-router - JHipster will add entities to the router here
   ],
 };


### PR DESCRIPTION
## Summary
- add ReadingVoucher entity with file storage and claim tracking
- expose REST endpoints to upload, claim, and list vouchers with scheduled issuance
- build Vue page and service for uploading and grabbing vouchers

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent due to network unreachable)*
- `npm test` *(fails: assertion difference in alert.service.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d8892be48322a2b3b9aadb9acbaa