### PR TITLE
Add hottest novels endpoint

### DIFF
--- a/src/main/java/com/shanzha/service/NovelRankService.java
+++ b/src/main/java/com/shanzha/service/NovelRankService.java
@@ -1,6 +1,8 @@
 package com.shanzha.service;
 
-
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -21,33 +23,39 @@ public class NovelRankService {
      */
     public void incrementReadCount(long novelId) {
         // 使用管道提高性能
-        stringRedisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-            // 1. HASH中增加阅读量
-            connection.hashCommands().hIncrBy(
-                    READ_COUNT_KEY.getBytes(),
-                    String.valueOf(novelId).getBytes(),
-                    1L);
+        stringRedisTemplate.executePipelined(
+            (RedisCallback<Object>) connection -> {
+                // 1. HASH中增加阅读量
+                connection.hashCommands().hIncrBy(READ_COUNT_KEY.getBytes(), String.valueOf(novelId).getBytes(), 1L);
 
-            // 2. ZSET中更新排行榜
-            Double currentScore = connection.zSetCommands().zScore(
-                    RANKING_KEY.getBytes(),
-                    String.valueOf(novelId).getBytes());
+                // 2. ZSET中更新排行榜
+                Double currentScore = connection.zSetCommands().zScore(RANKING_KEY.getBytes(), String.valueOf(novelId).getBytes());
 
-            connection.zSetCommands().zAdd(
-                    RANKING_KEY.getBytes(),
-                    (currentScore != null ? currentScore : 0) + 1,
-                    String.valueOf(novelId).getBytes());
+                connection
+                    .zSetCommands()
+                    .zAdd(RANKING_KEY.getBytes(), (currentScore != null ? currentScore : 0) + 1, String.valueOf(novelId).getBytes());
 
-            return null;
-        });
+                return null;
+            }
+        );
     }
 
     /**
      * 获取小说阅读量
      */
     public long getReadCount(long novelId) {
-        String count = (String) stringRedisTemplate.opsForHash()
-                .get(READ_COUNT_KEY, String.valueOf(novelId));
+        String count = (String) stringRedisTemplate.opsForHash().get(READ_COUNT_KEY, String.valueOf(novelId));
         return count != null ? Long.parseLong(count) : 0;
+    }
+
+    /**
+     * 获取排行榜前N的小说ID
+     */
+    public List<Long> getTopNovels(int limit) {
+        Set<String> ids = stringRedisTemplate.opsForZSet().reverseRange(RANKING_KEY, 0, limit - 1);
+        if (ids == null || ids.isEmpty()) {
+            return List.of();
+        }
+        return ids.stream().map(Long::valueOf).collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/shanzha/web/rest/controller/ReadController.java
+++ b/src/main/java/com/shanzha/web/rest/controller/ReadController.java
@@ -2,10 +2,15 @@ package com.shanzha.web.rest.controller;
 
 import com.shanzha.domain.CommonCodeMsg;
 import com.shanzha.service.ChapterContentService;
+import com.shanzha.service.NovelRankService;
 import com.shanzha.service.dto.ChapterContentDTO;
 import com.shanzha.web.rest.errors.BusinessException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RBucket;
 import org.redisson.api.RLock;
@@ -13,11 +18,6 @@ import org.redisson.api.RedissonClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 @RestController
 @RequestMapping("/api/read")
@@ -28,20 +28,20 @@ public class ReadController {
     @Autowired
     private ChapterContentService chapterContentService;
 
+    @Autowired
+    private NovelRankService novelRankService;
+
     @GetMapping("/{novel_id}/{chapter_id}/{page_id}")
     @Operation(summary = "阅读", description = "阅读")
-    public ResponseEntity<String> read(
-        @PathVariable Long novel_id,
-        @PathVariable Long chapter_id,
-        @PathVariable Long page_id
-    ) throws InterruptedException {
+    public ResponseEntity<String> read(@PathVariable Long novel_id, @PathVariable Long chapter_id, @PathVariable Long page_id)
+        throws InterruptedException {
         String result = chapterContentService.readChapterContent(novel_id, chapter_id, page_id);
         return ResponseEntity.ok(result);
     }
 
-
-    @GetMapping("/hotest_novel")
-    public ResponseEntity<List<Long>> getHot() {
-        return ResponseEntity.ok(null); // 待实现热门小说逻辑
+    @GetMapping("/hottest_novels")
+    public ResponseEntity<List<Long>> getHottestNovels(@RequestParam(defaultValue = "10") int limit) {
+        List<Long> topNovels = novelRankService.getTopNovels(limit);
+        return ResponseEntity.ok(topNovels);
     }
 }


### PR DESCRIPTION
## Summary
- Inject `NovelRankService` into `ReadController`
- Add `/hottest_novels` endpoint returning top novel IDs
- Implement `getTopNovels` in `NovelRankService`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a15f9eb083228ddaac0cca41f188