### PR TITLE
Clarify Bloom filter behavior in chapter deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ Unit tests are run by [Vitest][]. They're located near components and can be run
 
 ## Others
 
+### Bloom filter considerations
+
+Chapter content lookups use a Redis-backed Bloom filter (`RBloomFilter`) to avoid most cache penetration. This filter is
+append-only and does not support removing individual entries. When a chapter is deleted its key remains in the filter,
+so lookups may still hit the database once before a missing placeholder is cached. This behavior is expected and keeps
+deletion logic simple at the cost of one extra lookup after removal.
+
 ### Code quality using Sonar
 
 Sonar is used to analyse code quality. You can start a local Sonar server (accessible on http://localhost:9001) with:
@@ -228,7 +235,7 @@ docker compose -f src/main/docker/services.yml down
 ```yaml
 spring:
   ...
-  
+
     compose:
       enabled: false
 ```


### PR DESCRIPTION
## Summary
- note that chapter deletion only clears cache because Redisson Bloom filter entries are immutable and may yield one extra lookup
- document Bloom filter immutability and its impact on deleted chapters

## Testing
- `./mvnw -q compile` *(fails: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a160aef88322b02348079b4d6428