### PR TITLE
feat: add comment UI and mirror images

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] Java version (use -bullseye variants on local arm64/Apple Silicon): 17, 17-bullseye, 17-buster
 ARG VARIANT="17"
-FROM mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
+FROM 1ms.run/mcr.microsoft.com/vscode/devcontainers/java:0-${VARIANT}
 
 # [Option] Install Maven
 ARG INSTALL_MAVEN="false"

--- a/src/main/docker/mysql.yml
+++ b/src/main/docker/mysql.yml
@@ -2,7 +2,7 @@
 name: airead
 services:
   mysql:
-    image: mysql:9.2.0
+    image: 1ms.run/mysql:9.2.0
     volumes:
       - ./config/mysql:/etc/mysql/conf.d
     environment:

--- a/src/main/docker/redis.yml
+++ b/src/main/docker/redis.yml
@@ -2,7 +2,7 @@
 name: airead
 services:
   redis:
-    image: redis:8.0.0
+    image: 1ms.run/redis:8.0.0
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:

--- a/src/main/webapp/app/entities/comment/comment.component.ts
+++ b/src/main/webapp/app/entities/comment/comment.component.ts
@@ -1,0 +1,25 @@
+import { defineComponent, inject, onMounted, ref } from 'vue';
+import type CommentService from './comment.service';
+
+export default defineComponent({
+  compatConfig: { MODE: 3 },
+  name: 'Comment',
+  setup() {
+    const commentService = inject('commentService') as () => CommentService;
+    const comments = ref<any[]>([]);
+
+    const loadAll = () => {
+      commentService()
+        .retrieve()
+        .then(res => {
+          comments.value = res.data;
+        });
+    };
+
+    onMounted(() => {
+      loadAll();
+    });
+
+    return { comments, loadAll };
+  },
+});

--- a/src/main/webapp/app/entities/comment/comment.service.ts
+++ b/src/main/webapp/app/entities/comment/comment.service.ts
@@ -1,0 +1,7 @@
+import axios from 'axios';
+
+export default class CommentService {
+  public retrieve(): Promise<any> {
+    return axios.get('api/comments');
+  }
+}

--- a/src/main/webapp/app/entities/comment/comment.vue
+++ b/src/main/webapp/app/entities/comment/comment.vue
@@ -1,0 +1,8 @@
+<template>
+  <div>
+    <h2 id="comment-heading">Comments</h2>
+    <b-table :items="comments" :fields="['id', 'content']" responsive="sm"></b-table>
+  </div>
+</template>
+
+<script lang="ts" src="./comment.component.ts"></script>

--- a/src/main/webapp/app/entities/entities-menu.vue
+++ b/src/main/webapp/app/entities/entities-menu.vue
@@ -1,6 +1,7 @@
 <template>
   <div>
     <router-link to="/reading-voucher" class="dropdown-item">Reading Vouchers</router-link>
+    <router-link to="/comment" class="dropdown-item">Comments</router-link>
     <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
   </div>
 </template>

--- a/src/main/webapp/app/entities/entities.component.ts
+++ b/src/main/webapp/app/entities/entities.component.ts
@@ -2,6 +2,7 @@ import { defineComponent, provide } from 'vue';
 
 import UserService from '@/entities/user/user.service';
 import ReadingVoucherService from '@/entities/reading-voucher/reading-voucher.service';
+import CommentService from '@/entities/comment/comment.service';
 // jhipster-needle-add-entity-service-to-entities-component-import - JHipster will import entities services here
 
 export default defineComponent({
@@ -10,6 +11,7 @@ export default defineComponent({
   setup() {
     provide('userService', () => new UserService());
     provide('readingVoucherService', () => new ReadingVoucherService());
+    provide('commentService', () => new CommentService());
     // jhipster-needle-add-entity-service-to-entities-component - JHipster will import entities services here
   },
 });

--- a/src/main/webapp/app/router/entities.ts
+++ b/src/main/webapp/app/router/entities.ts
@@ -2,6 +2,7 @@ const Entities = () => import('@/entities/entities.vue');
 
 // jhipster-needle-add-entity-to-router-import - JHipster will import entities to the router here
 const ReadingVoucher = () => import('@/entities/reading-voucher/reading-voucher.vue');
+const Comment = () => import('@/entities/comment/comment.vue');
 
 export default {
   path: '/',
@@ -11,6 +12,11 @@ export default {
       path: 'reading-voucher',
       name: 'ReadingVoucher',
       component: ReadingVoucher,
+    },
+    {
+      path: 'comment',
+      name: 'Comment',
+      component: Comment,
     },
     // jhipster-needle-add-entity-to-router - JHipster will add entities to the router here
   ],


### PR DESCRIPTION
## Summary
- add Comment UI with service, route, and menu
- switch devcontainer/mysql/redis images to 1ms.run mirror

## Testing
- `npm run lint` *(fails: 15 errors)*
- `npm run vitest-run` *(fails: Alert Service test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d2e73da883229d08c6676d48f9bc