### PR TITLE
Add cache annotations and ranking cleanup for Novel service

### DIFF
--- a/src/main/java/com/shanzha/config/CacheConfiguration.java
+++ b/src/main/java/com/shanzha/config/CacheConfiguration.java
@@ -88,7 +88,10 @@ public class CacheConfiguration {
             createCache(cm, com.shanzha.domain.User.class.getName(), jcacheConfiguration);
             createCache(cm, com.shanzha.domain.Authority.class.getName(), jcacheConfiguration);
             createCache(cm, com.shanzha.domain.User.class.getName() + ".authorities", jcacheConfiguration);
-            createCache(cm, com.shanzha.domain.Novel.class.getName(), jcacheConfiguration);
+            MutableConfiguration<Object, Object> novelCacheConfiguration = new MutableConfiguration<>(
+                jcacheConfiguration
+            ).setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(new Duration(TimeUnit.HOURS, 1)));
+            createCache(cm, com.shanzha.domain.Novel.class.getName(), novelCacheConfiguration);
             createCache(cm, com.shanzha.domain.Chapter.class.getName(), jcacheConfiguration);
             createCache(cm, com.shanzha.domain.ChapterContent.class.getName(), jcacheConfiguration);
             createCache(cm, com.shanzha.domain.NovelTag.class.getName(), jcacheConfiguration);

--- a/src/main/java/com/shanzha/service/NovelRankService.java
+++ b/src/main/java/com/shanzha/service/NovelRankService.java
@@ -58,4 +58,12 @@ public class NovelRankService {
         }
         return ids.stream().map(Long::valueOf).collect(Collectors.toList());
     }
+
+    /**
+     * 删除排行榜和阅读量中的小说记录
+     */
+    public void removeFromRanking(long novelId) {
+        stringRedisTemplate.opsForZSet().remove(RANKING_KEY, String.valueOf(novelId));
+        stringRedisTemplate.opsForHash().delete(READ_COUNT_KEY, String.valueOf(novelId));
+    }
 }


### PR DESCRIPTION
## Summary
- cache Novel retrieval and mutations
- remove ranking entries when deleting novels
- set 1-hour TTL for Novel cache entries

## Testing
- `./mvnw -q -e -DskipTests compile` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1e5580c83229c319b9407975fe8