### PR TITLE
refactor: optimize ranking increment

### DIFF
--- a/src/main/java/com/shanzha/service/NovelRankService.java
+++ b/src/main/java/com/shanzha/service/NovelRankService.java
@@ -29,11 +29,7 @@ public class NovelRankService {
                 connection.hashCommands().hIncrBy(READ_COUNT_KEY.getBytes(), String.valueOf(novelId).getBytes(), 1L);
 
                 // 2. ZSET中更新排行榜
-                Double currentScore = connection.zSetCommands().zScore(RANKING_KEY.getBytes(), String.valueOf(novelId).getBytes());
-
-                connection
-                    .zSetCommands()
-                    .zAdd(RANKING_KEY.getBytes(), (currentScore != null ? currentScore : 0) + 1, String.valueOf(novelId).getBytes());
+                connection.zSetCommands().zIncrBy(RANKING_KEY.getBytes(), 1D, String.valueOf(novelId).getBytes());
 
                 return null;
             }

--- a/src/test/java/com/shanzha/service/NovelRankServiceTest.java
+++ b/src/test/java/com/shanzha/service/NovelRankServiceTest.java
@@ -1,0 +1,61 @@
+package com.shanzha.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.shanzha.IntegrationTest;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@IntegrationTest
+class NovelRankServiceTest {
+
+    @Autowired
+    private NovelRankService novelRankService;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
+
+    private static final String READ_COUNT_KEY = "novel:read:count";
+    private static final String RANKING_KEY = "novel:ranking";
+
+    @BeforeEach
+    void cleanRedis() {
+        stringRedisTemplate.delete(READ_COUNT_KEY);
+        stringRedisTemplate.delete(RANKING_KEY);
+    }
+
+    @Test
+    void shouldHandleConcurrentIncrement() throws InterruptedException {
+        long novelId = 1L;
+        int threadCount = 10;
+        int iterations = 100;
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executor.execute(() -> {
+                for (int j = 0; j < iterations; j++) {
+                    novelRankService.incrementReadCount(novelId);
+                }
+                latch.countDown();
+            });
+        }
+
+        latch.await();
+        executor.shutdown();
+
+        long expected = (long) threadCount * iterations;
+        assertThat(novelRankService.getReadCount(novelId)).isEqualTo(expected);
+        Double score = stringRedisTemplate.opsForZSet().score(RANKING_KEY, String.valueOf(novelId));
+        assertThat(score).isEqualTo((double) expected);
+        List<Long> top = novelRankService.getTopNovels(1);
+        assertThat(top).containsExactly(novelId);
+    }
+}


### PR DESCRIPTION
## Summary
- use `zIncrBy` to update ranking atomically
- add concurrency test for novel ranking service

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM for com.shanzha:ai-read:0.0.1-SNAPSHOT: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1e6e97083229e322485263a7ccc