### PR TITLE
feat: clean up data when deleting novel

### DIFF
--- a/src/main/java/com/shanzha/service/NovelService.java
+++ b/src/main/java/com/shanzha/service/NovelService.java
@@ -2,13 +2,12 @@ package com.shanzha.service;
 
 import com.shanzha.domain.Novel;
 import com.shanzha.repository.NovelRepository;
+import com.shanzha.service.dto.ChapterDTO;
 import com.shanzha.service.dto.NovelDTO;
 import com.shanzha.service.mapper.NovelMapper;
-
 import java.io.IOException;
 import java.util.*;
 import java.util.stream.Collectors;
-
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.apache.poi.hwpf.HWPFDocument;
@@ -18,6 +17,7 @@ import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -30,12 +30,22 @@ import org.springframework.web.multipart.MultipartFile;
 public class NovelService {
 
     private static final Logger LOG = LoggerFactory.getLogger(NovelService.class);
-    private static final String RANK_KEY = "novel:read:rank";;
+    private static final String RANK_KEY = "novel:read:rank";
+    private static final String RANKING_KEY = "novel:ranking";
+    private static final String READ_COUNT_KEY = "novel:read:count";
 
     private final NovelRepository novelRepository;
 
     private final NovelMapper novelMapper;
 
+    @Autowired
+    private ChapterService chapterService;
+
+    @Autowired
+    private ChapterContentService chapterContentService;
+
+    @Autowired
+    private StringRedisTemplate stringRedisTemplate;
 
     public String parseFile(MultipartFile file) throws IOException {
         String filename = file.getOriginalFilename();
@@ -60,10 +70,10 @@ public class NovelService {
             throw new IllegalArgumentException("Unsupported file type");
         }
     }
+
     public NovelService(NovelRepository novelRepository, NovelMapper novelMapper) {
         this.novelRepository = novelRepository;
         this.novelMapper = novelMapper;
-
     }
 
     /**
@@ -142,13 +152,25 @@ public class NovelService {
      */
     public void delete(Long id) {
         LOG.debug("Request to delete Novel : {}", id);
+
+        // 先删除章节内容及缓存
+        List<ChapterDTO> chapters = chapterService.findByNovelId(id);
+        for (ChapterDTO chapter : chapters) {
+            chapterContentService.deleteChapterContents(id, chapter.getId());
+        }
+
+        // 移除排行榜和阅读量数据
+        stringRedisTemplate.opsForZSet().remove(RANKING_KEY, String.valueOf(id));
+        stringRedisTemplate.opsForHash().delete(READ_COUNT_KEY, String.valueOf(id));
+
+        // 重建布隆过滤器避免误判
+        chapterContentService.initBloomFilter();
+
         novelRepository.deleteById(id);
     }
 
     public List<Long> getTop10HottestNovelIds() {
         Map<String, Double> rankMap = RedisClient.getTopZSetWithScore(RANK_KEY, 10);
-        return rankMap.keySet().stream()
-            .map(Long::valueOf)
-            .collect(Collectors.toList());
+        return rankMap.keySet().stream().map(Long::valueOf).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Summary
- purge chapter caches and rebuild bloom filter when deleting novel
- drop novel from Redis ranking and read count keys on deletion

## Testing
- `mvn -q -e -DskipTests package` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.4.5)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1e80e0c83229675b1a2a6d5d375