### PR TITLE
feat: add user coupon list page

### DIFF
--- a/src/main/webapp/app/core/jhi-navbar/jhi-navbar.vue
+++ b/src/main/webapp/app/core/jhi-navbar/jhi-navbar.vue
@@ -24,6 +24,10 @@
             <span>首页</span>
           </span>
         </b-nav-item>
+        <b-nav-item to="/coupons" v-if="authenticated">
+          <font-awesome-icon icon="gift" />
+          <span>我的优惠券</span>
+        </b-nav-item>
         <b-nav-item-dropdown right id="entity-menu" v-if="authenticated" active-class="active" class="pointer" data-cy="entity">
           <template #button-content>
             <span class="navbar-dropdown-menu">

--- a/src/main/webapp/app/coupon/coupon-list.vue
+++ b/src/main/webapp/app/coupon/coupon-list.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <h2>我的优惠券</h2>
+    <div v-if="coupons.length === 0">暂无优惠券</div>
+    <table v-else class="table table-striped">
+      <thead>
+        <tr>
+          <th>券码</th>
+          <th>过期时间</th>
+          <th>状态</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="coupon in coupons" :key="coupon.id">
+          <td>{{ coupon.code }}</td>
+          <td>{{ formatDateShort(coupon.expireTime) }}</td>
+          <td>{{ coupon.used ? '已使用' : isExpired(coupon) ? '已过期' : '未使用' }}</td>
+          <td>
+            <button v-if="!coupon.used && !isExpired(coupon)" class="btn btn-primary btn-sm" @click="useCoupon(coupon.id)">使用</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import UserCouponService from './user-coupon.service';
+import { useDateFormat } from '@/shared/composables/date-format';
+
+const service = new UserCouponService();
+const coupons = ref<any[]>([]);
+const { formatDateShort } = useDateFormat();
+
+const load = async () => {
+  const res = await service.listMy();
+  coupons.value = res.data;
+};
+
+const useCoupon = async (id: number) => {
+  await service.use(id);
+  await load();
+};
+
+const isExpired = (coupon: any) => coupon.expireTime && new Date(coupon.expireTime) < new Date();
+
+onMounted(load);
+</script>

--- a/src/main/webapp/app/coupon/user-coupon.service.ts
+++ b/src/main/webapp/app/coupon/user-coupon.service.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+
+export default class UserCouponService {
+  listMy(page = 0) {
+    return axios.get('api/user-coupons/my', { params: { page } });
+  }
+
+  use(couponId: number) {
+    return axios.post('api/user-coupons/use', { couponId });
+  }
+}

--- a/src/main/webapp/app/novel/novel-upload.vue
+++ b/src/main/webapp/app/novel/novel-upload.vue
@@ -3,30 +3,30 @@
     <h2>小说上传解析</h2>
     <input type="file" @change="onFileChange" />
     <button @click="upload" :disabled="!file">上传并解析</button>
-  <pre v-if="content">{{ content }}</pre>
-</div>
+    <pre v-if="content">{{ content }}</pre>
+  </div>
 </template>
 
 <script setup lang="ts">
-  import { ref } from 'vue';
-  import NovelService from './novel.service';
+import { ref } from 'vue';
+import NovelService from './novel.service';
 
-  const novelService = new NovelService();
-  const file = ref<File | null>(null);
-  const content = ref('');
+const novelService = new NovelService();
+const file = ref<File | null>(null);
+const content = ref('');
 
-  const onFileChange = (e: Event) => {
+const onFileChange = (e: Event) => {
   const target = e.target as HTMLInputElement;
   if (target.files && target.files.length > 0) {
-  file.value = target.files[0];
-} else {
-  file.value = null;
-}
+    file.value = target.files[0];
+  } else {
+    file.value = null;
+  }
 };
 
-  const upload = async () => {
+const upload = async () => {
   if (file.value) {
-  content.value = await novelService.parse(file.value);
-}
+    content.value = await novelService.parse(file.value);
+  }
 };
 </script>

--- a/src/main/webapp/app/router/pages.ts
+++ b/src/main/webapp/app/router/pages.ts
@@ -1,4 +1,5 @@
 const NovelUpload = () => import('@/novel/novel-upload.vue');
+const CouponList = () => import('@/coupon/coupon-list.vue');
 // jhipster-needle-add-entity-to-router-import - JHipster will import entities to the router here
 
 export default [
@@ -7,5 +8,6 @@ export default [
     name: 'NovelUpload',
     component: NovelUpload,
   },
+  { path: '/coupons', name: 'CouponList', component: CouponList },
   // jhipster-needle-add-entity-to-router - JHipster will add entities to the router here
 ];

--- a/src/main/webapp/app/shared/alert/alert.service.spec.ts
+++ b/src/main/webapp/app/shared/alert/alert.service.spec.ts
@@ -32,7 +32,7 @@ describe('Alert Service test suite', () => {
   });
 
   it('should show not reachable toast when http status = 0', async () => {
-    const message = 'Server not reachable';
+    const message = '服务器无法访问';
     const httpErrorResponse = {
       status: 0,
     };
@@ -105,7 +105,7 @@ describe('Alert Service test suite', () => {
   });
 
   it('should show error toast when http status = 404', async () => {
-    const message = 'The page does not exist.';
+    const message = '该页面不存在.';
     const httpErrorResponse = {
       status: 404,
     };


### PR DESCRIPTION
## Summary
- add user coupon service and list view
- expose coupon list route and nav entry
- update alert service spec for localized messages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aacbc743bc8322903d787cc3b71f97