### PR TITLE
chore: add Docker deployment setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+target
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+# Build stage
+FROM maven:3.9.6-eclipse-temurin-17 AS build
+WORKDIR /app
+COPY pom.xml mvnw .
+COPY .mvn .mvn
+COPY package.json package-lock.json* .
+COPY src src
+# Install dependencies and build application
+RUN chmod +x mvnw && ./mvnw -Pprod -DskipTests package
+
+# Runtime stage
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /app/target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - '8080:8080'
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysql:3306/aiRead?useUnicode=true&characterEncoding=utf8&useSSL=false&useLegacyDatetimeCode=false&createDatabaseIfNotExist=true
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: secret
+      JHIPSTER_CACHE_REDIS_SERVER: redis://redis:6379
+    depends_on:
+      - mysql
+      - redis
+
+  mysql:
+    image: mysql:8.0
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: aiRead
+      MYSQL_ROOT_PASSWORD: secret
+    ports:
+      - '3306:3306'
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+  redis:
+    image: redis:7
+    restart: unless-stopped
+    ports:
+      - '6379:6379'
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
## Summary
- add multi-stage Dockerfile for building and running the app
- add docker-compose.yml with MySQL and Redis
- ignore build artifacts with .dockerignore

## Testing
- `./mvnw -q test` *(fails: Could not transfer artifact spring-boot-starter-parent)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac6ef1e6588322a0d6e4f94fd688c0