### PR TITLE
chore: improve docker compose deployment

### DIFF
--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,12 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>aliyun</id>
+      <mirrorOf>*</mirrorOf>
+      <name>Aliyun Maven Mirror</name>
+      <url>https://maven.aliyun.com/repository/public</url>
+    </mirror>
+  </mirrors>
+</settings>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,16 @@
 # Build stage
-FROM maven:3.9.6-eclipse-temurin-17 AS build
+FROM docker.1ms.run/maven:3.9.6-eclipse-temurin-17 AS build
 WORKDIR /app
 COPY pom.xml mvnw .
 COPY .mvn .mvn
 COPY package.json package-lock.json* .
 COPY src src
 # Install dependencies and build application
-RUN chmod +x mvnw && ./mvnw -Pprod -DskipTests package
+RUN mkdir -p /root/.m2 && cp .mvn/settings.xml /root/.m2/settings.xml \
+    && chmod +x mvnw && ./mvnw -Pprod -DskipTests package
 
 # Runtime stage
-FROM eclipse-temurin:17-jre
+FROM docker.1ms.run/eclipse-temurin:17-jre
 WORKDIR /app
 COPY --from=build /app/target/*.jar app.jar
 EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -211,6 +211,18 @@ For more information, refer to the [Code quality page][].
 
 JHipster generates a number of Docker Compose configuration files in the [src/main/docker/](src/main/docker/) folder to launch required third party services.
 
+#### One-click deployment
+
+This project also provides a top-level `docker-compose.yml` for quickly bringing up the full stack. Images are pulled from the `docker.1ms.run` mirror and the application image is built using the Aliyun Maven mirror defined in [.mvn/settings.xml](.mvn/settings.xml).
+
+To build and start all services, run:
+
+```bash
+docker compose up -d
+```
+
+The first execution builds the application image and then starts the app, MySQL and Redis containers. Subsequent runs reuse the built image.
+
 For example, to start required services in Docker containers, run:
 
 ```
@@ -228,7 +240,7 @@ docker compose -f src/main/docker/services.yml down
 ```yaml
 spring:
   ...
-  
+
     compose:
       enabled: false
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - redis
 
   mysql:
-    image: mysql:8.0
+    image: docker.1ms.run/mysql:8.0
     restart: unless-stopped
     environment:
       MYSQL_DATABASE: aiRead
@@ -26,7 +26,7 @@ services:
       - mysql-data:/var/lib/mysql
 
   redis:
-    image: redis:7
+    image: docker.1ms.run/redis:7
     restart: unless-stopped
     ports:
       - '6379:6379'


### PR DESCRIPTION
## Summary
- use docker.1ms.run mirror images in Dockerfile and docker-compose
- add Aliyun Maven mirror configuration
- document one-click Docker Compose deployment

## Testing
- `docker compose config` *(fails: command not found)*
- `./mvnw -s .mvn/settings.xml -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ade44b3d788322993bf91a82feb13b